### PR TITLE
Potential fix for code scanning alert no. 6: Uncontrolled data used in path expression

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -3,6 +3,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from fastapi.staticfiles import StaticFiles
 from fastapi.responses import FileResponse, RedirectResponse
 from pathlib import Path
+from werkzeug.utils import secure_filename
 from .config import settings
 import os
 
@@ -120,8 +121,13 @@ async def serve_frontend(full_path: str):
     if ".." in full_path or full_path.startswith("/"):
         return FileResponse(STATIC_DIR / "index.html")
     
-    # Check if this is a static file request
-    static_file = (STATIC_DIR / full_path).resolve()
+    # Check if this is a static file request, sanitize each path segment
+    segments = full_path.split('/')
+    safe_segments = [secure_filename(seg) for seg in segments if seg and seg not in ('.', '..')]
+    static_file = STATIC_DIR
+    for seg in safe_segments:
+        static_file = static_file / seg
+    static_file = static_file.resolve()
     
     # Ensure the resolved path is within STATIC_DIR
     try:

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,4 +1,5 @@
 fastapi==0.122.0
+werkzeug==3.1.3
 uvicorn[standard]==0.38.0
 SQLAlchemy==2.0.44
 psycopg2-binary==2.9.11


### PR DESCRIPTION
Potential fix for [https://github.com/tokendad/NesVentory/security/code-scanning/6](https://github.com/tokendad/NesVentory/security/code-scanning/6)

To fully mitigate the uncontrolled path risk, we should restrict user-supplied `full_path` so that it cannot contain path separators, dot-dots, backslashes, or any other unsafe characters. For static assets, it's best to allow only file names that have been sanitized or that match an allowlist. If subdirectory access is needed, sanitize each path segment and recompose the full path. The most robust single fix is to use `secure_filename` from `werkzeug.utils` on every segment of `full_path` before constructing `static_file`. If directory trees more than one level deep are required, we'll split the path into segments, sanitize each, and then reconstruct the path. We'll need to add an import for `secure_filename`, split and sanitize the segments, and construct the path only from sanitized segments. The changes are all within the `serve_frontend` function in backend/app/main.py, beginning at line 93.

#### Steps:
- Add an import for `secure_filename`: `from werkzeug.utils import secure_filename`
- In `serve_frontend`, before using `full_path`, split it into segments and sanitize each with `secure_filename`.
- Reconstruct `static_file` from `STATIC_DIR` joining the sanitized segments, and then `.resolve()` as before.
- Continue to check using `.relative_to()` as before for belt-and-braces protection.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
