### PR TITLE
Potential fix for code scanning alert no. 8: Information exposure through an exception

### DIFF
--- a/backend/app/routers/encircle.py
+++ b/backend/app/routers/encircle.py
@@ -358,8 +358,8 @@ def process_encircle_import(
         
     except Exception as e:
         db.rollback()
-        result.errors.append(str(e))
-        result.log.append(f"Error: {e}")
+        result.errors.append("An internal error occurred during import.")
+        result.log.append("Import failed due to an internal error.")
         logger.exception("Encircle import failed")
     
     return result


### PR DESCRIPTION
Potential fix for [https://github.com/tokendad/NesVentory/security/code-scanning/8](https://github.com/tokendad/NesVentory/security/code-scanning/8)

To fix the problem, we should avoid exposing raw exception messages or stack traces to the user. Instead, we should return a generic error message in the `result.errors` and `result.log` fields that does not reveal internal server details. We should log full exception details using the existing logger for developer use, but redact detailed info from the external-facing response. Specifically, in the exception handler inside `process_encircle_import`, replace `result.errors.append(str(e))` and `result.log.append(f"Error: {e}")` with neutral, non-sensitive messages such as `"An error occurred during import."` or `"Internal error."` Optionally, you can retain very high-level error codes or references that do not identify specifics.

#### What is needed:
- Update lines in the exception handler inside `process_encircle_import` so user-exposed results use generic wording.
- No new imports or method definitions are necessary.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
