### PR TITLE
Potential fix for code scanning alert no. 13: Information exposure through an exception

### DIFF
--- a/backend/app/routers/encircle.py
+++ b/backend/app/routers/encircle.py
@@ -786,7 +786,7 @@ def preview_encircle_import(xlsx_content: bytes, filename: Optional[str] = None)
         return {
             "parent_location_name": None,
             "success": False,
-            "error": str(e)
+            "error": "An error occurred while previewing the Encircle file."
         }
 
 


### PR DESCRIPTION
Potential fix for [https://github.com/tokendad/NesVentory/security/code-scanning/13](https://github.com/tokendad/NesVentory/security/code-scanning/13)

The best way to fix this problem is to return a generic error message to the client, while continuing to log detailed error information (including stack traces) for server-side diagnostics. Specifically:  
- In the `preview_encircle_import` function, when an exception occurs, continue logging the exception using `logger.exception`, but do not include the actual exception string (`str(e)`) in the returned dictionary.  
- Instead, include a generic error message in the dictionary returned on error (e.g., `"error": "An error occurred while previewing the Encircle file."`).  
- This will ensure that the API response (in the `detail` field of the `HTTPException`) only shows a safe, generic error to the client.

You only need to change the error block inside the `except` clause (lines 786-789) of `preview_encircle_import`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
